### PR TITLE
Update TVS count for hospital.py

### DIFF
--- a/TVS count for hospital.py
+++ b/TVS count for hospital.py
@@ -5,7 +5,22 @@ def getval(N,R1,R2,target):
     tvcount=0
     peoplecount=0
     currenttarget=0
-    Months=[31,28,31,30,31,30,31,31,30,31,30,31]
-    for i in range()
+    Months=[0,31,28,31,30,31,30,31,31,30,31,30,31]
+    for i in range(1,N+1):
+        tvcount=i
+        currenttarget=0
+        for M in range(1,13):
+            for D in range(1,(Months[M])+1):
+                peoplecount=getpersoncount(D,M)
+                peoplecount=min(N,peoplecount)
+                if(peoplecount<=N-tvcount):
+                    currenttarget+=peoplecount*R2
+                else:
+                    currenttarget=currenttarget+(((N-tvcount)*R2)+(peoplecount - (N-tvcount))*R1)
+        print(currenttarget,tvcount)
+        if(currenttarget>=target):
+            break;
+    print(tvcount)
 
 N,R1,R2,target=20,1500,1000,7000000
+getval(N,R1,R2,target)


### PR DESCRIPTION
Patients per day = (6 – M)2 + |D – 15|
where,
M: the number of month starting from 1 to 12
D: the date from 1 to 31
All patients prefer without TV rooms as they are cheaper, but will opt for with TV rooms only if without TV rooms are not available. Hospital has a revenue target for the first year of operation. Given this target and the values of N, R1, and R2 you need to identify the number of TVs the hospital should buy so that it meets the revenue target. Assume the Hospital opens on 1st Jan and year is a non-leap year.

Input: N = 20, R1 = 1500, R2 = 1000, target = 7000000
Output: 14
Explanation:
Using the formula:
The number of patients on 1st Jan will be 39, on 2nd Jan will be 38 and so on.
Considering there are only twenty rooms and rates of both type of rooms are 1500 and 1000 respectively.
Therefore, 14 TV sets are needed to get the revenue of 7119500 with 13 TV sets.
The total revenue will be less than 7000000.

Input: N = 10, R1 = 1000, R2 = 1500, target = 10000000
Output: 10
Explanation:
In the above example, the target will not be achieved, even by equipping all the rooms with TV.
Hence, the answer is 10 i.e., total number of rooms in the hospital.